### PR TITLE
BLMENG-25 Updated InputProcessor's audio event triggering

### DIFF
--- a/Core/include/AudioEngine.h
+++ b/Core/include/AudioEngine.h
@@ -10,6 +10,7 @@
 #include "EntityManager.h"
 #include "Event.h"
 #include "Audio.h"
+#include "InputProcessor.h"
 
 #include <../../../vendor/fmod/api/core/inc/fmod.h>
 #include <../../../vendor/fmod/api/core/inc/fmod.hpp>
@@ -28,7 +29,7 @@
 
 class AudioEngine {
 public:
-    AudioEngine(EntityManager& entityManager);
+    AudioEngine(EntityManager& entityManager, InputProcessor& inputProcessor);
     bool Initialize();
     void SetBank(int entityUID, std::string bankPath);
     std::string getEntityBank(int entityUID);
@@ -46,6 +47,8 @@ public:
 
 private:
     EntityManager& entityManager;
+    InputProcessor& inputProcessor;
+
     FMOD::Studio::System* system = nullptr;
     FMOD::System* coreSystem;
     FMOD::Sound* sound = nullptr;

--- a/Core/include/InputProcessor.h
+++ b/Core/include/InputProcessor.h
@@ -14,6 +14,8 @@
 #ifndef BLOOM_ENGINE_INPUTPROCESSOR_H
 #define BLOOM_ENGINE_INPUTPROCESSOR_H
 
+#include <unordered_set>
+
 #include "Entity.h"
 #include "KeyCodes.h"
 #include "EntityManager.h"
@@ -22,6 +24,7 @@
 #include "Player.h"
 #include "Transform.h"
 #include "Physics.h"
+
 #include "../../vendor/sol2/include/sol/sol.hpp"
 
 /**
@@ -51,6 +54,8 @@ public:
     void ProcessInput(SDL_Event& event);
     void registerKeyDownCallback(KeyCode keyCode, sol::function callback);
     void registerKeyUpCallback(KeyCode keyCode, sol::function callback);
+    bool isKeyPressed(KeyCode keyCode);
+    std::unordered_set<KeyCode> pressedKeys;
 private:
     EntityManager& entityManager; ///< Reference to the engine's entity manager.
     Dispatcher& dispatcher; ///< Reference to the engine's event dispatcher.

--- a/Core/src/AudioEngine.cpp
+++ b/Core/src/AudioEngine.cpp
@@ -4,7 +4,7 @@
 
 #include "../include/AudioEngine.h"
 
-AudioEngine::AudioEngine(EntityManager& entityManager) : entityManager(entityManager) {}
+AudioEngine::AudioEngine(EntityManager& entityManager, InputProcessor& inputProcessor) : entityManager(entityManager), inputProcessor(inputProcessor) {}
 
 bool AudioEngine::Initialize() {
     FMOD_RESULT result = FMOD::Studio::System::create(&system);
@@ -168,18 +168,25 @@ void AudioEngine::HandleInputEvent(const Event& event) {
     std::cout << "[INFO] AudioEngine::HandleInputEvent() called" << std::endl;
 
     if(event.eventType == EventType::InputKeyDown) {
-    auto eventInstance = PlayEvent(event.entityUID, "walking", "event:/Walking");
-    eventInstance->setParameterByName("repeat", 1.0);
+        std::cout << "[DEBUG] HandleInputEvent() InputKeyDown called" << std::endl;
+        if (inputProcessor.pressedKeys.size() == 1) {
+            auto eventInstance = PlayEvent(event.entityUID, "walking", "event:/Walking");
+            eventInstance->setParameterByName("repeat", 1.0);
+        }
     }
+
     if(event.eventType == EventType::InputKeyUp) {
         std::cout << "[DEBUG] HandleInputEvent() InputKeyUp called" << std::endl;
-        auto& audioComponent = entityManager.getEntityComponent<Audio>(event.entityUID, ComponentType::Audio);
-        if (audioComponent.eventInstances.count("walking") > 0) {
-            FMOD::Studio::EventInstance* eventInstance = audioComponent.eventInstances["walking"];
-            eventInstance->stop(FMOD_STUDIO_STOP_IMMEDIATE);
-            eventInstance->release();
-            audioComponent.eventInstances.erase("walking");
+        if (inputProcessor.pressedKeys.empty()) {
+            auto& audioComponent = entityManager.getEntityComponent<Audio>(event.entityUID, ComponentType::Audio);
+            if (audioComponent.eventInstances.count("walking") > 0) {
+                FMOD::Studio::EventInstance* eventInstance = audioComponent.eventInstances["walking"];
+                eventInstance->stop(FMOD_STUDIO_STOP_IMMEDIATE);
+                eventInstance->release();
+                audioComponent.eventInstances.erase("walking");
+            }
         }
+
     }
 }
 

--- a/Core/src/Core.cpp
+++ b/Core/src/Core.cpp
@@ -14,7 +14,7 @@ Core::Core() : window(nullptr), isRunning(false), fileSystem(), stateMachine(ent
                inputProcessor(entityManager,dispatcher), renderingEngine(entityManager, dispatcher),
                animationEngine(entityManager, dispatcher, deltaTime),
                collisionEngine(entityManager, dispatcher),
-               audioEngine(entityManager),
+               audioEngine(entityManager, inputProcessor),
                scriptingEngine(lua, inputProcessor, entityManager, dispatcher, renderingEngine, animationEngine,
                                physicsEngine, collisionEngine, audioEngine) {}
 

--- a/Core/src/InputProcessor.cpp
+++ b/Core/src/InputProcessor.cpp
@@ -8,12 +8,17 @@
 
 // ProcessInput is called in the Core MainLoop() function if the SDL Event is detected as a SDL_Key event
 void InputProcessor::ProcessInput(SDL_Event& event) {
+    // Extract the SDL_Keycode and cast it to your KeyCode enum
+    auto keyCode = static_cast<KeyCode>(event.key.keysym.sym);
     if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP) {
-        // Extract the SDL_Keycode and cast it to your KeyCode enum
-        KeyCode keyCode = static_cast<KeyCode>(event.key.keysym.sym);
+
+
 
         // Check and trigger key down callbacks
         if (event.type == SDL_KEYDOWN) {
+            if (!event.key.repeat) {
+                pressedKeys.insert(keyCode);
+            }
             if (!event.key.repeat && keyDownCallbacks.find(keyCode) != keyDownCallbacks.end()) {
                 for (auto& callback : keyDownCallbacks[keyCode]) {
                     callback();  // Execute each callback associated with the key code
@@ -23,6 +28,7 @@ void InputProcessor::ProcessInput(SDL_Event& event) {
 
         // Check and trigger key up callbacks if needed
         if (event.type == SDL_KEYUP) {
+            pressedKeys.erase(keyCode);
             if (keyUpCallbacks.find(keyCode) != keyUpCallbacks.end()) {
                 for (auto& callback : keyUpCallbacks[keyCode]) {
                     callback();  // Execute each callback associated with the key code
@@ -38,4 +44,8 @@ void InputProcessor::registerKeyDownCallback(KeyCode keyCode, sol::function call
 
 void InputProcessor::registerKeyUpCallback(KeyCode keyCode, sol::function callback) {
     keyUpCallbacks[keyCode].push_back(callback);
+}
+
+bool InputProcessor::isKeyPressed(KeyCode keyCode) {
+    return pressedKeys.find(keyCode) != pressedKeys.end();
 }


### PR DESCRIPTION
InputProcessor didn't take into account all keys pressed. This means that if multiple keys were pressed, and one was released...audio events would stop even though a key was still pressed and audio should continue playing. This has been fixed by adding std::unordered_set<KeyCode> pressedKeys and supporting logic.