### PR TITLE
BLMENG-27 Updated InputProcessor's animation triggering

### DIFF
--- a/Core/include/AnimationEngine.h
+++ b/Core/include/AnimationEngine.h
@@ -11,6 +11,7 @@
 //#include <SDL_image.h>
 
 #include "EntityManager.h"
+#include "InputProcessor.h"
 #include "Dispatcher.h"
 #include "Animation.h"
 #include "Sprite.h"
@@ -19,8 +20,8 @@
 
 class AnimationEngine {
     public:
-    explicit AnimationEngine(EntityManager& entityManager, Dispatcher& dispatcher, float& deltaTime) :
-                                entityManager(entityManager), dispatcher(dispatcher), deltaTime(deltaTime) {} ;
+    explicit AnimationEngine(EntityManager& entityManager, InputProcessor& inputProcessor, Dispatcher& dispatcher, float& deltaTime) :
+                                entityManager(entityManager), inputProcessor(inputProcessor), dispatcher(dispatcher), deltaTime(deltaTime) {} ;
 
     void addFrame(int entityUID, AnimationType animationType, SDL_Texture *frame);
     std::vector<SDL_Texture*>& getAnimationType(int entityUID, AnimationType animationType);
@@ -32,6 +33,7 @@ class AnimationEngine {
 
 private:
     EntityManager& entityManager;
+    InputProcessor& inputProcessor;
     Dispatcher& dispatcher;
     static SDL_Renderer* renderer;
     float& deltaTime;

--- a/Core/include/InputProcessor.h
+++ b/Core/include/InputProcessor.h
@@ -55,11 +55,16 @@ public:
     void registerKeyDownCallback(KeyCode keyCode, sol::function callback);
     void registerKeyUpCallback(KeyCode keyCode, sol::function callback);
     bool isKeyPressed(KeyCode keyCode);
-    std::unordered_set<KeyCode> pressedKeys;
+    const std::unordered_set<KeyCode> getPressedKeys();
+    void setLastPressedKey(KeyCode keyCode);
+    const KeyCode getLastPressedKey();
+
 private:
     EntityManager& entityManager; ///< Reference to the engine's entity manager.
     Dispatcher& dispatcher; ///< Reference to the engine's event dispatcher.
     EventData eventData; ///< Struct to hold processed event data before dispatching.
+    std::unordered_set<KeyCode> pressedKeys;
+    KeyCode lastPressedKey;
     std::unordered_map<KeyCode, std::vector<sol::function>> keyDownCallbacks;
     std::unordered_map<KeyCode, std::vector<sol::function>> keyUpCallbacks;
 

--- a/Core/src/AudioEngine.cpp
+++ b/Core/src/AudioEngine.cpp
@@ -45,7 +45,6 @@ bool AudioEngine::Initialize() {
 }
 
 void AudioEngine::SetBank(int entityUID, std::string bankPath) {
-
     if (entityManager.hasComponent(entityUID, ComponentType::Audio)) {
         auto& audio = entityManager.getEntityComponent<Audio>(entityUID, ComponentType::Audio);
         audio.bankPath = bankPath;
@@ -59,7 +58,6 @@ std::string AudioEngine::getEntityBank(int entityUID) {
     auto& audio = entityManager.getEntityComponent<Audio>(entityUID, ComponentType::Audio);
     return audio.bankPath;
 }
-
 
 bool AudioEngine::LoadBank(const std::string& bankPath) {
     std::cout << "Loading Bank: " << bankPath << std::endl;
@@ -147,13 +145,11 @@ FMOD::Studio::EventInstance* AudioEngine::PlayEvent(int entityUID, const std::st
         std::cerr << "Error: Failed to create event instance for " << eventPath
         << ". Error: " << FMOD_ErrorString(result) << std::endl;
     }
-
     result = eventInstance->start();
     if (result != FMOD_OK) {
         std::cerr << "Error: Failed to start event " << eventPath
         << ". Error: " << FMOD_ErrorString(result) << std::endl;
     }
-
     audioComponent.eventInstances[eventName] = eventInstance;
     std::cout << "[INFO] AudioEngine::PlayEvent(" << eventName << ", " << eventPath << ")" << std::endl;
     activeEvents.emplace(eventPath, eventInstance);
@@ -166,18 +162,17 @@ void AudioEngine::Update() {
 
 void AudioEngine::HandleInputEvent(const Event& event) {
     std::cout << "[INFO] AudioEngine::HandleInputEvent() called" << std::endl;
-
+    auto& pressedKeys = inputProcessor.getPressedKeys();
     if(event.eventType == EventType::InputKeyDown) {
         std::cout << "[DEBUG] HandleInputEvent() InputKeyDown called" << std::endl;
-        if (inputProcessor.pressedKeys.size() == 1) {
+        if (pressedKeys.size() == 1) {
             auto eventInstance = PlayEvent(event.entityUID, "walking", "event:/Walking");
             eventInstance->setParameterByName("repeat", 1.0);
         }
     }
-
     if(event.eventType == EventType::InputKeyUp) {
         std::cout << "[DEBUG] HandleInputEvent() InputKeyUp called" << std::endl;
-        if (inputProcessor.pressedKeys.empty()) {
+        if (pressedKeys.empty()) {
             auto& audioComponent = entityManager.getEntityComponent<Audio>(event.entityUID, ComponentType::Audio);
             if (audioComponent.eventInstances.count("walking") > 0) {
                 FMOD::Studio::EventInstance* eventInstance = audioComponent.eventInstances["walking"];
@@ -186,7 +181,6 @@ void AudioEngine::HandleInputEvent(const Event& event) {
                 audioComponent.eventInstances.erase("walking");
             }
         }
-
     }
 }
 

--- a/Core/src/Core.cpp
+++ b/Core/src/Core.cpp
@@ -12,7 +12,7 @@ Core::Core() : window(nullptr), isRunning(false), fileSystem(), stateMachine(ent
                dispatcher(entityManager),
                physicsEngine(entityManager, dispatcher, deltaTime),
                inputProcessor(entityManager,dispatcher), renderingEngine(entityManager, dispatcher),
-               animationEngine(entityManager, dispatcher, deltaTime),
+               animationEngine(entityManager, inputProcessor, dispatcher, deltaTime),
                collisionEngine(entityManager, dispatcher),
                audioEngine(entityManager, inputProcessor),
                scriptingEngine(lua, inputProcessor, entityManager, dispatcher, renderingEngine, animationEngine,

--- a/Core/src/InputProcessor.cpp
+++ b/Core/src/InputProcessor.cpp
@@ -12,8 +12,6 @@ void InputProcessor::ProcessInput(SDL_Event& event) {
     auto keyCode = static_cast<KeyCode>(event.key.keysym.sym);
     if (event.type == SDL_KEYDOWN || event.type == SDL_KEYUP) {
 
-
-
         // Check and trigger key down callbacks
         if (event.type == SDL_KEYDOWN) {
             if (!event.key.repeat) {
@@ -28,6 +26,7 @@ void InputProcessor::ProcessInput(SDL_Event& event) {
 
         // Check and trigger key up callbacks if needed
         if (event.type == SDL_KEYUP) {
+            setLastPressedKey(keyCode);
             pressedKeys.erase(keyCode);
             if (keyUpCallbacks.find(keyCode) != keyUpCallbacks.end()) {
                 for (auto& callback : keyUpCallbacks[keyCode]) {
@@ -48,4 +47,16 @@ void InputProcessor::registerKeyUpCallback(KeyCode keyCode, sol::function callba
 
 bool InputProcessor::isKeyPressed(KeyCode keyCode) {
     return pressedKeys.find(keyCode) != pressedKeys.end();
+}
+
+const std::unordered_set<KeyCode> InputProcessor::getPressedKeys() {
+    return pressedKeys;
+}
+
+void InputProcessor::setLastPressedKey(KeyCode keyCode) {
+    lastPressedKey = keyCode;
+}
+
+const KeyCode InputProcessor::getLastPressedKey() {
+    return lastPressedKey;
 }

--- a/Editor/include/Editor.cpp
+++ b/Editor/include/Editor.cpp
@@ -37,8 +37,8 @@ void Editor::Initialize() {
     style.Colors[ImGuiCol_ButtonHovered] = ImVec4(255.0f, 0, 200.0f, 0.5f);
 
     // Redirect cout and cerr to the custom stream buffer
-    std::cout.rdbuf(&consoleStreamBuffer);
-    std::cerr.rdbuf(&consoleStreamBuffer);
+    //std::cout.rdbuf(&consoleStreamBuffer);
+    //std::cerr.rdbuf(&consoleStreamBuffer);
 
     // Load Bloom Engine logo for Viewport splash screen (when no camera component found)
     bloomEngineSplashScreen = IMG_LoadTexture(renderingEngine.GetRenderer(),


### PR DESCRIPTION
InputProcessor was incorrectly handling animation triggering when multiple keys were pressed/released. Animation cycle now correctly updates to the most current key being pressed. Animation cycles now stop at frame 0 to prevent mid cycle frame stops. 